### PR TITLE
Fix nginx conf to not have duplicate http block

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -1,31 +1,33 @@
-http {
+client_max_body_size 50m;
+etag off;
+merge_slashes off;
 
-    client_max_body_size 50m;
-    etag off;
-    merge_slashes off;
 
-    # This is required to thwart nginx's file cache when using virtual box.
+server {
+    listen  80 default;
+
+    # This is required to thwart nginx's file
+    # cache when using virtual box.
     sendfile off;
 
-    server {
-        listen  80 default;
-
-        location / {
-            alias /srv/payments-example/;
-        }
+    location / {
+        alias /srv/payments-example/;
     }
+}
 
-    server {
-        listen  8000 default;
+server {
+    listen  8000 default;
 
-        location / {
-            proxy_pass http://payments-service;
-            proxy_set_header Host $host;
-        }
+    # This is required to thwart nginx's file
+    # cache when using virtual box.
+    sendfile off;
+
+    location / {
+        proxy_pass http://payments-service;
+        proxy_set_header Host $host;
     }
+}
 
-    upstream payments-service {
-        server payments-service:8000;
-    }
-
+upstream payments-service {
+    server payments-service:8000;
 }


### PR DESCRIPTION
The nginx conf for payments-env is included into an `http` block by the default conf at /etc/nginx/nginx.conf so the current conf which has an `http` block in it causes nginx to blow up with an error "http directive is not allowed here"

This fixes it so nginx runs. The sendfile option is duplicated inside the server blocks because otherwise nginx bleats about it being a duplicate of the rule in the main http block.
