### PR TITLE
Show git clone command in link.py error

### DIFF
--- a/link.py
+++ b/link.py
@@ -24,8 +24,11 @@ def main():
         full_name = os.path.join(args.root, name)
         if not os.path.exists(full_name):
             print
-            print ('** Repository at {path} does not exist. '
-                   'Is it checked out?'.format(path=full_name))
+            print (
+                '** Repository at {path} does not exist. Run:\n'
+                'git clone git@github.com:mozilla/{repo_name}.git {path}'
+                .format(path=full_name, repo_name=name)
+            )
             print
             errors = True
             continue


### PR DESCRIPTION
I guess this is approaching the auto-cloning feature of mkt-env so maybe we can
also port that over to docker-utils. I'm still liking the symlinking approach
best though.
