### PR TITLE
Replace normpath with abspath in link.py

### DIFF
--- a/link.py
+++ b/link.py
@@ -11,7 +11,7 @@ def main():
     args = parser.parse_args()
     if not args.root:
         args.root = raw_input('What directory is your source code in? ')
-    args.root = os.path.normpath(os.path.expanduser(args.root))
+    args.root = os.path.abspath(os.path.expanduser(args.root))
     payments_env_root = os.path.dirname(__file__)
 
     errors = False


### PR DESCRIPTION
Enables the following use case:

```
~/mozilla/payments-env$ python link.py
What directory is your source code in? ..
docker/source-links/payments-example -> /Users/jgmize/mozilla/payments-example
docker/source-links/payments-service -> /Users/jgmize/mozilla/payments-service
docker/source-links/payments-ui -> /Users/jgmize/mozilla/payments-ui
docker/source-links/solitude -> /Users/jgmize/mozilla/solitude
```

Without this change, link.py creates symlinks relative to `docker/source-links`:

```
~/mozilla/payments-env$ python link.py
What directory is your source code in? ..
docker/source-links/payments-example -> ../payments-example
docker/source-links/payments-service -> ../payments-service
docker/source-links/payments-ui -> ../payments-ui
docker/source-links/solitude -> ../solitude
```
