### PR TITLE
Add source-only FxA storage server (kinto) to docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ The following instructions are for developing on the code only.
 
 * Check out the following repositories somewhere on your machine under the same
   root directory:
-  * [solitude](https://github.com/mozilla/solitude/)
-  * [solitude-auth](https://github.com/mozilla/solitude-auth/)
+  * [kinto](https://github.com/mozilla-services/kinto/)
   * [payments-example](https://github.com/mozilla/payments-example/)
   * [payments-service](https://github.com/mozilla/payments-service/)
   * [payments-ui](https://github.com/mozilla/payments-ui/)
+  * [solitude](https://github.com/mozilla/solitude/)
+  * [solitude-auth](https://github.com/mozilla/solitude-auth/)
 * Run ``python link.py`` to connect your sources.
 * Export any project-specific environment variables in your shell.
   * Example: for Solitude you'll need to

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,23 @@ mysqldata:
       file: configs/base.yml
       service: mysqldata
 
+postgres:
+  image: postgres
+  environment:
+    POSTGRES_USER: postgres
+    POSTGRES_PASSWORD: postgres
+
+# FxA storage server.
+kinto:
+  build: ./docker/source-links/kinto/
+  links:
+    - postgres:db
+  ports:
+   - "8888:8888"
+  environment:
+    CLIQUET_SESSION_URL: postgres://postgres:postgres@db/postgres
+    CLIQUET_STORAGE_URL: postgres://postgres:postgres@db/postgres
+
 ui:
   extends:
       file: configs/base.yml

--- a/link.py
+++ b/link.py
@@ -16,6 +16,7 @@ def main():
 
     errors = False
     for name in [
+        'kinto',
         'payments-example',
         'payments-service',
         'payments-ui',


### PR DESCRIPTION
Once we have hosted images we can adjust this for the deploy environments.

This gets me:

```
$ curl http://pay.dev:8888/v1/
{"url":"http:\/\/pay.dev:8888\/v1\/","documentation":"https:\/\/kinto.rtfd.org\/","version":"1.0.0.dev0","hello":"cloud storage"}
```
