### PR TITLE
Add report-only CSP header (fixes mozilla/payments#108)

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -24,6 +24,14 @@ server {
     # cache when using virtual box.
     sendfile off;
 
+    # Add some default CSP in report-only mode.
+    add_header Content-Security-Policy-Report-Only "
+        default-src 'self' *.dev.lcip.org;
+        font-src 'self';
+        img-src 'self';
+        script-src 'self' *.braintreegateway.com;
+        style-src 'self'";
+
     location /api/ {
         proxy_pass http://payments-service;
         proxy_set_header Host $host;


### PR DESCRIPTION
A starting point for looking at any CSP violations in the console. 

Note: This will only affect non-webpack-dev-server usage because webpack uses express. Will be good to look at on AWS for example or local dev without webpack.
